### PR TITLE
Enclose table name in backticks in SHOW CREATE TABLE, added aggregateFunction clickhouse types

### DIFF
--- a/src/ClickHousePlatform.php
+++ b/src/ClickHousePlatform.php
@@ -190,6 +190,22 @@ class ClickHousePlatform extends AbstractPlatform
             'array(nullable(string))' => 'array',
             'array(nullable(date))' => 'array',
             'array(nullable(datetime))' => 'array',
+
+            'aggregatefunction(max, int8)' => 'array',
+            'aggregatefunction(max, int16)' => 'array',
+            'aggregatefunction(max, int32)' => 'array',
+            'aggregatefunction(argmax, int8, int8)' => 'array',
+            'aggregatefunction(argmax, int8, int16)' => 'array',
+            'aggregatefunction(argmax, int8, int32)' => 'array',
+            'aggregatefunction(argmax, int16, int8)' => 'array',
+            'aggregatefunction(argmax, int16, int16)' => 'array',
+            'aggregatefunction(argmax, int16, int32)' => 'array',
+            'aggregatefunction(argmax, int32, int8)' => 'array',
+            'aggregatefunction(argmax, int32, int16)' => 'array',
+            'aggregatefunction(argmax, int32, int32)' => 'array',
+            'aggregatefunction(argmax, string, int8)' => 'array',
+            'aggregatefunction(argmax, string, int16)' => 'array',
+            'aggregatefunction(argmax, string, int32)' => 'array',
         ];
     }
 

--- a/src/ClickHouseSchemaManager.php
+++ b/src/ClickHouseSchemaManager.php
@@ -54,7 +54,7 @@ class ClickHouseSchemaManager extends AbstractSchemaManager
      */
     protected function _getPortableViewDefinition($view)
     {
-        $statement = $this->_conn->fetchColumn('SHOW CREATE TABLE ' . $view['name']);
+        $statement = $this->_conn->fetchColumn('SHOW CREATE TABLE `' . $view['name'].'`');
 
         return new View($view['name'], $statement);
     }


### PR DESCRIPTION
# Added feature:

Added 'aggregateFunction' (maxState/argMaxState) type mapping for integer fields. Needed for AggregatingMergeTree table engine usage with  with max/argMax.

# Fixed bug 

Doctrine migrations terminates if the materialized views' inner tables are present in database schema. Reason: inner tables are named like '.inner_id.1234-abc-def-444aaabbb', *ClickhouseSchemaManager:: _getPortableViewDefinition()* _will not enclose table name in backticks_ and produces syntax error.